### PR TITLE
Covscan issues

### DIFF
--- a/common.h
+++ b/common.h
@@ -66,7 +66,7 @@ static inline size_t lprint_strlcat(char *dst, const char *src, size_t dstsize)
     srclen = dstsize;
   memmove(dst + dstlen, src, srclen);
   dst[dstlen + srclen] = '\0';
-  return (dstlen = srclen);
+  return (dstlen + srclen);
 }
 #    define strlcpy(dst,src,dstsize) lprint_strlcpy(dst,src,dstsize)
 static inline size_t lprint_strlcpy(char *dst, const char *src, size_t dstsize)

--- a/lprint-delete.c
+++ b/lprint-delete.c
@@ -41,7 +41,8 @@ lprintDoDelete(
   }
   else if ((http = lprintConnect(1)) == NULL)
     return (1);
-  else if ((printer_name = cupsGetOption("printer-name", num_options, options)) == NULL)
+
+  if ((printer_name = cupsGetOption("printer-name", num_options, options)) == NULL)
   {
     fputs("lprint: No printer specified.\n", stderr);
     httpClose(http);

--- a/server-client.c
+++ b/server-client.c
@@ -1193,6 +1193,12 @@ show_add(lprint_client_t *client)	// I - Client connection
       }
     }
 
+    if (!device_uri)
+    {
+      valid = 0;
+      error = "No device uri provided.";
+    }
+
     if (valid)
     {
       // Add the printer...


### PR DESCRIPTION
Hi Mike,

I'm preparing lprint for packaging into Fedora and during that I ran our Coverity scan. It is called covscan - it is a set of static analyzers e.g. cppcheck, shellcheck, and compilers with enabled analytical options - gcc and clang. The result is an aggregation of warnings and errors during their run with scanned project.

We have a set of error types which are important e.g. memory leaks, double frees, buffer overflows - the scan didn't report any of them for lprint. It found three other, less important errors 
[covscan.txt](https://github.com/michaelrsweet/lprint/files/5040221/covscan.txt) , for which I propose fixes in this pull request.

Every reported error has a single commit with message which reported error it fixes.

Would you mind reviewing those and possibly merging the fixes into LPrint? Please let me know whether I should change something.

Thank you in advance,

Zdenek
 