### PR TITLE
server-ipp.c: set the current datetime to startup time, if no printer…

### DIFF
--- a/server-ipp.c
+++ b/server-ipp.c
@@ -1557,6 +1557,12 @@ ipp_get_system_attributes(
         state_time = printer->state_time;
     }
 
+    /*
+     * If there are no printers, take the startup time
+     */
+    if (state_time == 0)
+      state_time = system->start_time;
+
     if (!ra || cupsArrayFind(ra, "system-state-change-date-time"))
       ippAddDate(client->response, IPP_TAG_SYSTEM, "system-state-change-date-time", ippTimeToDate(state_time));
 


### PR DESCRIPTION
…s available

Hi,

when you ran ```lprint server``` but you don't have any device capable of working with lprint and if you issue:

```lprint status```

from other terminal, the return time is the beginning of linux timestamp - 1 hour - 1st Jan 1970.

It is because ipp attribute ```system-state-change-date-time``` contains ```0```, because there are no found printers  - their state time is used otherwise.

My proposed fix is to set ```state_time``` to ```system->start_time``` if no printers are available, but I'm not sure how to handle ```system-state-change-time``` attribute - it contained a negative integer before the proposed fix, now it will contain zero - can the attribute be ignored if value is zero?

Either way, please let me know if original fix is ok or should I change something.

Thank you in advance,

Zdenek