### PR TITLE
configure: Add --with-systemd option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -56,6 +56,7 @@ sharedstatedir	=	@sharedstatedir@
 srcdir		=	@srcdir@
 sysconfdir	=	@sysconfdir@
 top_srcdir	=	@top_srcdir@
+unitdir	=	@unitdir@
 
 BUILDROOT	=	$(DSTROOT)$(RPM_BUILD_ROOT)$(DESTDIR)
 
@@ -130,10 +131,10 @@ install:	all
 	    echo "Installing launchd service to $(BUILDROOT)/Library/LaunchDaemons..."; \
 	    $(INSTALL) -d -m 755 $(BUILDROOT)/Library/LaunchDaemons; \
 	    $(INSTALL) -c -m 644 org.msweet.lprint.plist $(BUILDROOT)/Library/LaunchDaemons; \
-	else \
-	    echo "Installing systemd service to $(BUILDROOT)$(sysconfdir)/systemd/system..."; \
-	    $(INSTALL) -d -m 755 $(BUILDROOT)$(sysconfdir)/systemd/system; \
-	    $(INSTALL) -c -m 644 lprint.service $(BUILDROOT)$(sysconfdir)/systemd/system; \
+	elif test x$unitdir != x; then \
+	    echo "Installing systemd service to $(BUILDROOT)$(unitdir)..."; \
+	    $(INSTALL) -d -m 755 $(BUILDROOT)$(unitdir); \
+	    $(INSTALL) -c -m 644 lprint.service $(BUILDROOT)$(unitdir); \
 	fi
 
 

--- a/configure
+++ b/configure
@@ -619,6 +619,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 OPTIM
 CSFLAGS
+unitdir
 CUPSCONFIG
 PKGCONFIG
 INSTALL
@@ -688,6 +689,7 @@ enable_option_checking
 enable_debug
 enable_maintainer
 enable_sanitizer
+with_systemd
 with_ldflags
 '
       ac_precious_vars='build_alias
@@ -1327,6 +1329,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-systemd=PATH     install systemd service file, default=yes
   --with-ldflags=...      Specify additional LDFLAGS
 
 Some influential environment variables:
@@ -2347,6 +2350,14 @@ CFLAGS="${CFLAGS:=}"
 CXXFLAGS="${CXXFLAGS:=}"
 LDFLAGS="${LDFLAGS:=}"
 LIBS="${LIBS:=}"
+
+
+if test $prefix = NONE
+then :
+
+    prefix=$ac_default_prefix
+
+fi
 
 
 
@@ -3871,6 +3882,59 @@ fi
 if test ${enable_sanitizer+y}
 then :
   enableval=$enable_sanitizer;
+fi
+
+
+
+
+# Check whether --with-systemd was given.
+if test ${with_systemd+y}
+then :
+  withval=$with_systemd;
+    case $withval in #(
+  yes) :
+
+	with_systemd=yes
+	unitdir=${prefix}/lib/systemd/system
+     ;; #(
+  no) :
+
+	with_systemd=no
+     ;; #(
+  *) :
+
+	with_systemd=yes
+	unitdir=$withval
+     ;;
+esac
+
+else $as_nop
+
+    with_systemd=yes
+    unitdir=${prefix}/lib/systemd/system
+
+fi
+
+
+
+if test `uname` != "Darwin" && test x$with_systemd = xyes
+then :
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for systemd unit directory" >&5
+printf %s "checking for systemd unit directory... " >&6; }
+    if test x$unitdir != x
+then :
+
+
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $unitdir" >&5
+printf "%s\n" "$unitdir" >&6; }
+
+else $as_nop
+
+	as_fn_error $? "Path to the unit dir is empty." "$LINENO" 5
+
+fi
+
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,12 @@ LDFLAGS="${LDFLAGS:=}"
 LIBS="${LIBS:=}"
 
 
+dnl Figure out prefix - needed for systemd unit dir
+AS_IF([test $prefix = NONE], [
+    prefix=$ac_default_prefix
+], [])
+
+
 dnl Standard programs...
 AC_PROG_CC
 AC_PROG_RANLIB
@@ -109,6 +115,38 @@ dnl Extra compiler options...
 AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug], [turn on debugging, default=no]))
 AC_ARG_ENABLE([maintainer], AS_HELP_STRING([--enable-maintainer], [turn on maintainer mode, default=no]))
 AC_ARG_ENABLE([sanitizer], AS_HELP_STRING([--enable-sanitizer], [build with AddressSanitizer, default=no]))
+
+
+AC_ARG_WITH([systemd], AS_HELP_STRING([--with-systemd[=PATH]], [install systemd service file, default=yes]),
+[
+    AS_CASE([$withval], [yes], [
+	with_systemd=yes
+	unitdir=${prefix}/lib/systemd/system
+    ], [no], [
+	with_systemd=no
+    ], [
+	with_systemd=yes
+	unitdir=$withval
+    ])
+], [
+    with_systemd=yes
+    unitdir=${prefix}/lib/systemd/system
+])
+
+
+dnl Substitute unitdir macro if we aren't on Darwin and want systemd...
+AS_IF([test `uname` != "Darwin" && test x$with_systemd = xyes], [
+    AC_MSG_CHECKING([for systemd unit directory])
+    AS_IF([test x$unitdir != x], [
+	AC_SUBST([unitdir])
+	AC_MSG_RESULT([$unitdir])
+    ],
+    [
+	AC_MSG_ERROR([Path to the unit dir is empty.])
+    ])
+],
+[])
+
 
 AS_IF([test x$enable_debug = xyes], [
     OPTIM="-g"


### PR DESCRIPTION
NEW:

The option gives a way how to disable systemd unit file installation and provides a way how to define a different systemd unit dir.

OLD version:

- enable possibility to turn off systemd unit file's installation
  (some distitributions can still work without systemd)
- enable possibility to add a specific path to systemd unit dir
  via UNITDIR variable (if not used, /usr/lib/systemd/system is chosen)
- install lprint.service into /usr/lib/systemd/system by default -
  /etc/systemd/system is for admin's overrides