### PR TITLE
Fix test for systemd units directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -131,7 +131,7 @@ install:	all
 	    echo "Installing launchd service to $(BUILDROOT)/Library/LaunchDaemons..."; \
 	    $(INSTALL) -d -m 755 $(BUILDROOT)/Library/LaunchDaemons; \
 	    $(INSTALL) -c -m 644 org.msweet.lprint.plist $(BUILDROOT)/Library/LaunchDaemons; \
-	elif test x$unitdir != x; then \
+	elif test x${unitdir} != x; then \
 	    echo "Installing systemd service to $(BUILDROOT)$(unitdir)..."; \
 	    $(INSTALL) -d -m 755 $(BUILDROOT)$(unitdir); \
 	    $(INSTALL) -c -m 644 lprint.service $(BUILDROOT)$(unitdir); \


### PR DESCRIPTION
Without curly braces the Makefile will always return true because
an empty $unitdir value resolves to "nitdir". Makefiles are "fun".