### PR TITLE
Add warnings to cflags and fix for ZPL naming

### DIFF
--- a/configure
+++ b/configure
@@ -4002,6 +4002,8 @@ then :
 
 fi
 
+    CFLAGS="$CFLAGS $WARNINGS"
+
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether compiler supports -fPIE" >&5
 printf %s "checking whether compiler supports -fPIE... " >&6; }
     OLDCFLAGS="$CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,8 @@ AS_IF([test -n "$GCC"], [
 	WARNINGS="$WARNINGS -Werror"
     ])
 
+    CFLAGS="$CFLAGS $WARNINGS"
+
     dnl See if PIE options are supported...
     AC_MSG_CHECKING(whether compiler supports -fPIE)
     OLDCFLAGS="$CFLAGS"

--- a/lprint.c
+++ b/lprint.c
@@ -341,7 +341,7 @@ printer_cb(const char     *device_info,	// I - Device information
       for (i = 2; i < 100; i ++)
       {
         snprintf(newname, sizeof(newname), "%s %d", name, i);
-        if (papplPrinterCreate(system, 0, name, driver_name, device_id, device_uri))
+        if (papplPrinterCreate(system, 0, newname, driver_name, device_id, device_uri))
           break;
       }
     }

--- a/lprint.c
+++ b/lprint.c
@@ -316,7 +316,7 @@ printer_cb(const char     *device_info,	// I - Device information
 
   if (driver_name)
   {
-    char	name[1024],		// Printer name
+    char	name[1020],		// Printer name
 		*nameptr;		// Pointer in name
 
 


### PR DESCRIPTION
I noticed a Wformat-truncation warning while compiling lprint, even though configure checks that the warning can be disabled.

I've tried to fix it by adding it to CFLAGS in configure{.ac}, as it seemed as the simplest solution.
I also tried a fix for the warning - I guess printer names > 1020 characters would be unusual anyway?

And I then couldn't understand why the newname wasn't used, so I tried to make sense of it (Untested, I don't have multiple ZPL printers)

I've separated it into three patches, so feel free to cherry pick if any of it is of use.