### PR TITLE
configure.ac: Don't hardcode path in .service file

### DIFF
--- a/configure
+++ b/configure
@@ -4112,7 +4112,7 @@ then :
 fi
 
 
-ac_config_files="$ac_config_files Makefile"
+ac_config_files="$ac_config_files Makefile lprint.service"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -4801,6 +4801,7 @@ do
   case $ac_config_target in
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "lprint.service") CONFIG_FILES="$CONFIG_FILES lprint.service" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -232,5 +232,8 @@ AC_ARG_WITH(ldflags, AS_HELP_STRING([--with-ldflags=...], [Specify additional LD
 ])
 
 dnl Generate the Makefile...
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([
+    Makefile
+    lprint.service
+])
 AC_OUTPUT

--- a/lprint.service.in
+++ b/lprint.service.in
@@ -7,7 +7,7 @@ Requires=avahi-daemon.socket
 WantedBy=multi-user.target
 
 [Service]
-ExecStart=/usr/local/bin/lprint server -o log-file=- -o log-level=debug
+ExecStart=@bindir@/lprint server -o log-file=- -o log-level=debug
 Type=simple
 Restart=on-failure
 


### PR DESCRIPTION
plist and service files have the path hardcoded - use the path from configure.ac.