### PR TITLE
Default the log level to info in the systemd service

### DIFF
--- a/lprint.service.in
+++ b/lprint.service.in
@@ -7,7 +7,7 @@ Requires=avahi-daemon.socket
 WantedBy=multi-user.target
 
 [Service]
-ExecStart=@bindir@/lprint server -o log-file=- -o log-level=debug
+ExecStart=@bindir@/lprint server -o log-file=- -o log-level=info
 Type=simple
 Restart=on-failure
 


### PR DESCRIPTION
The equivalent `plist` in macOS uses `info` which seems like a better default.