### PR TITLE
configure.ac: Fix bindir expansion (fixes #81)

### DIFF
--- a/configure
+++ b/configure
@@ -2359,6 +2359,20 @@ then :
 
 fi
 
+if test "$exec_prefix" = "NONE"
+then :
+
+    exec_prefix="$prefix"
+
+fi
+
+if test "$bindir" = "\${exec_prefix}/bin"
+then :
+
+    bindir="$exec_prefix/bin"
+
+fi
+
 
 
 
@@ -3723,19 +3737,6 @@ else
   PKGCONFIG="$ac_cv_path_PKGCONFIG"
 fi
 
-
-
-#AC_PATH_TOOL([CUPSCONFIG], [cups-config])
-#
-#AS_IF([$PKGCONFIG --exists cups], [
-#    CFLAGS="$CFLAGS $($PKGCONFIG --cflags cups)"
-#    LIBS="$LIBS $($PKGCONFIG --libs cups)"
-#], [test "x$CUPSCONFIG" != x], [
-#    CFLAGS="$CFLAGS $($CUPSCONFIG --cflags)"
-#    LIBS="$LIBS $($CUPSCONFIG --libs)"
-#], [
-#    AC_MSG_ERROR([CUPS is required for LPrint.])
-#])
 
 
 if $PKGCONFIG --exists pappl --atleast-version=1.1

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,16 @@ AS_IF([test $prefix = NONE], [
     prefix=$ac_default_prefix
 ], [])
 
+dnl Fix "exec_prefix" variable if it hasn't been specified...
+AS_IF([test "$exec_prefix" = "NONE"], [
+    exec_prefix="$prefix"
+])
+
+dnl Fix "bindir" variable...
+AS_IF([test "$bindir" = "\${exec_prefix}/bin"], [
+    bindir="$exec_prefix/bin"
+])
+
 
 dnl Standard programs...
 AC_PROG_CC


### PR DESCRIPTION
In case --exec-prefix is not defined as a configure option, the `exec-prefix` variable is not set, althought GNU manual says it should be set to `/usr/local`.

I used the same construction as we have in CUPS.