### PR TITLE
Remove unsupported options from lprint-modify manpage

### DIFF
--- a/man/lprint-modify.1
+++ b/man/lprint-modify.1
@@ -15,12 +15,6 @@ lprint-modify \- modify a printer queue.
 .B \-d
 .I PRINTER
 [
-.B \-m
-.I DRIVER-NAME
-] [
-.B \-v
-.I DEVICE-URI
-] [
 .B \-o
 .I OPTION=VALUE
 ]
@@ -30,12 +24,6 @@ lprint-modify \- modify a printer queue.
 .B \-u
 .I PRINTER-URI
 [
-.B \-m
-.I DRIVER-NAME
-] [
-.B \-v
-.I DEVICE-URI
-] [
 .B \-o
 .I OPTION=VALUE
 ]


### PR DESCRIPTION
The driver and the device URI cannot be modified.