### PR TITLE
TSPL: Set initial darkness_configured to 53

### DIFF
--- a/lprint-tspl.c
+++ b/lprint-tspl.c
@@ -158,7 +158,7 @@ lprintTSPL(
   data->tracking_supported = PAPPL_MEDIA_TRACKING_GAP | PAPPL_MEDIA_TRACKING_MARK | PAPPL_MEDIA_TRACKING_CONTINUOUS;
 
   // Darkness/density settings...
-  data->darkness_configured = 50;
+  data->darkness_configured = 53;
   data->darkness_supported  = 16;
 
   return (true);


### PR DESCRIPTION
53% is a valid value in the web interface and will be selected on the configuration page. In contrast, 50% is not a valid value, so 0% is selected, which is misleading.

53% corresponds to the density 8 in the range from 0 to 15 inclusive, which is the TSPL default.