### PR TITLE
Revert DYMO label margins to values prior to DYMO tape printing being added

### DIFF
--- a/lprint-dymo.c
+++ b/lprint-dymo.c
@@ -182,8 +182,8 @@ lprintDYMO(
     data->x_default = data->y_default = 300;
 
     // Media...
-    data->left_right = 367;
-    data->bottom_top = 1;
+    data->left_right = 100;
+    data->bottom_top = 525;
 
     data->num_media = (int)(sizeof(lprint_dymo_label) / sizeof(lprint_dymo_label[0]));
     memcpy(data->media, lprint_dymo_label, sizeof(lprint_dymo_label));


### PR DESCRIPTION
When DYMO tape printing support was added in ed195b5233 and 6f49c6e066, the label `left_right` margin was changed from 100 to 367 and the `bottom_top` margin from 525 to 1.

In my limited testing (I currently only have a LabelWriter 450 and 1.4 x 3.5" Large Address labels to test it with), these values cause the label content to be offset both vertically and horizontally with respect to the label.  For instance, after selecting the correct media, printing the test page gives me this result (next label manually ejected too for clarity):

![before](https://github.com/michaelrsweet/lprint/assets/961548/7d85b41b-00f9-42f9-92e4-ac29ff0cef30)

The commit in this PR restores the values to what they were prior to ed195b5233 and gives me the following result from the test page:

![after](https://github.com/michaelrsweet/lprint/assets/961548/77d6d4c8-cd01-42e1-8f03-3ab8f15d1e03)

This was initially a bit of a head-scratcher for me because I hadn't realised that the margins are stored in the state file and only updated when media is selected (or re-selected).