### PR TITLE
Add label definitions with a width of 105 mm

### DIFF
--- a/lprint-tspl.c
+++ b/lprint-tspl.c
@@ -82,6 +82,9 @@ static const char * const lprint_tspl_media[] =
   "oe_4x8-label_4x8in",
   "oe_4x13-label_4x13in",
 
+  "om_105x220mm-label_105x220mm",
+  "om_105x250mm-label_105x250mm",
+
   "roll_max_4x39.6in",
   "roll_min_0.75x0.25in"
 };


### PR DESCRIPTION
lprint seems to pick the maximum allowed width as the maximum supported label size width. This PR adds some 105mm label sizes to the TSPL driver to allow labels wider than 4in.

I'm not sure this is an ideal solution, though. What if some label printer supports, say, A4 width labels? Wouldn't it be better to allow arbitrary label sizes in pappl, or define an explicit and configurable max width parameter?