### PR TITLE
Make brother driver work for PT-E550W

### DIFF
--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -448,7 +448,11 @@ lprint_brother_rstartjob(
     darkness = 100;
 
   // 64 == auto-cut
-  papplDevicePrintf(device, "\033iM%c", !strcmp(options->media.type, "continuous") ? 64 : 0);
+  // TODO: Is this not reversed? Continuous should mean *no* autocut?
+  //papplDevicePrintf(device, "\033iM%c", !strcmp(options->media.type, "continuous") ? 64 : 0);
+  papplDevicePrintf(device, "\033iM%c", 64);
+  // 8 = nochain (cut at at end)
+  papplDevicePrintf(device, "\033iK%c", 8);
 
   return (papplDevicePrintf(device, "\033iD%c", 4 * darkness / 100 + 1));
 }

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -525,14 +525,15 @@ lprint_brother_rwriteline(
     // TODO: Add PackBits compression support
     brother->count += 3 + brother->dither.out_width;
 
-    *bufptr++ = 'g';
     if (brother->is_pt_series)
     {
+      *bufptr++ = 'G';
       *bufptr++ = brother->dither.out_width & 255;
       *bufptr++ = (brother->dither.out_width >> 8) & 255;
     }
     else
     {
+      *bufptr++ = 'g';
       *bufptr++ = 0;
       *bufptr++ = brother->dither.out_width;
     }

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -173,12 +173,10 @@ lprintBrother(
     data->source[0]  = "main-roll";
 
     papplCopyString(data->media_ready[0].size_name, "oe_wide-2in-tape_1x2in", sizeof(data->media_ready[0].size_name));
-    papplCopyString(data->media_ready[0].type, "labels", sizeof(data->media_ready[0].type));
+    papplCopyString(data->media_ready[0].type, "tape", sizeof(data->media_ready[0].type));
 
-    data->num_type = 2;
-    data->type[0]  = "continuous";
-    data->type[1]  = "continuous-film";
-    data->type[2]  = "continuous-removable";
+    data->num_type = 1;
+    data->type[0]  = "tape";
   }
 
   data->num_source = 1;

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -374,7 +374,7 @@ lprint_brother_rendpage(
   buffer[ 9] = (brother->count >> 16) & 255;
   buffer[10] = (brother->count >> 24) & 255;
 #endif // 1
-  buffer[11] = page == 0 ? 0 : 1;
+  buffer[11] = page == 1 ? 0 : 1;
   buffer[12] = 0;
 
   if (!papplDeviceWrite(device, buffer, sizeof(buffer)))

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -384,8 +384,7 @@ lprint_brother_rendpage(
   if (brother->num_bytes > 0 && !papplDeviceWrite(device, brother->buffer, brother->num_bytes))
     return (false);
 
-  // Eject/cut
-  papplDevicePrintf(device, "\033iM%c\014", !strcmp(options->media.type, "continuous") ? 64 : 0);
+  papplDevicePrintf(device, "\014");
   papplDeviceFlush(device);
 
   // Free memory and return...
@@ -448,6 +447,9 @@ lprint_brother_rstartjob(
     darkness = 0;
   else if (darkness > 100)
     darkness = 100;
+
+  // 64 == auto-cut
+  papplDevicePrintf(device, "\033iM%c", !strcmp(options->media.type, "continuous") ? 64 : 0);
 
   return (papplDevicePrintf(device, "\033iD%c", 4 * darkness / 100 + 1));
 }

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -384,7 +384,8 @@ lprint_brother_rendpage(
   if (brother->num_bytes > 0 && !papplDeviceWrite(device, brother->buffer, brother->num_bytes))
     return (false);
 
-  papplDevicePrintf(device, "\014");
+  // End of last page
+  papplDevicePrintf(device, "\x1a");
   papplDeviceFlush(device);
 
   // Free memory and return...

--- a/lprint-brother.h
+++ b/lprint-brother.h
@@ -43,5 +43,7 @@
   "MFG:Brother;CMD:PT-CBP;MDL:QL-1110NWB;", NULL },
 { "brother_ql-1115nwb",	"Brother QL-1115NWB",
   "MFG:Brother;CMD:PT-CBP;MDL:QL-1115NWB;", NULL },
+{ "brother_pt-e550w",	"Brother PT-E550W",
+  "MFG:Brother;CMD:PT-CBP;MDL:PT-E550W;", NULL },
 //{ "brother_pt-",	"Brother PT-",
 //  "MFG:Brother;CMD:???;MDL:PT-;", NULL },


### PR DESCRIPTION
With the commits in this PR, I can make my Brother PT-E550W print labels. It is not perfect, but at least it can print something.

About the commits:
 - The first couple of commits are reasonable and might be mergeable as-is. I also checked these against the docs for QL-800 and QL-1100, so they should also work on QL printers.
 - cb5b0a7d4256e337b491e0d3e8319a4463e889e5 about media sizes needs some feedback - I'm quite confused about all this business with media sizes, ready media, media types, media classes and whatnot. That commit helps to make things not crash or fail (see also https://github.com/michaelrsweet/pappl/pull/385), but is probably not correct.
 - 52eb01461f3b56ceac58501c514fcae0fd2e7b36 is a hack that just enables all cutting unconditionally. Without this, the printer would only feed long labels. I should check the brother application to see what that generates when cutting is disabled to fix this in a nicer way.

There are still some issues with the print margins: It seems that we might need to generate longer raster lines and include the printer margins as zero pixels in the data, but I am not entirely sure yet. It seems there might also be some scaling and offsetting going on (in the printer), so trying to print a full 12mm wide label ends up with the label being shifted, but I think not scaled. Documentation is a bit vague here: it suggests that for RLE/TIFF, you always need to generate full lines, (16 bytes for my 128-pixel E550W, 90 bytes for the 720-pixel QL-800 or 162 bytes for the 1296-pixel QL-1100), but maybe for non-RLE/TIFF you need to include left margin but can omit right margin (see docs for the M command). I haven't looked closely enough at lprint/pappl's media/page size handling to say something meaningful about this now.


I also looked at the darkness/density option (which my E550W does not support, but also does not mind), and had the following considerations (no commits about this yet):
 - Why is darkness_supported set to 5? Seems like a boolean?
 - Where is the darkness/print density command (ESC i D) documented? I could not find it the couple of manuals I looked at.
 - Does it make sense to only use the density command for printers that support it? My PT-E550W does not support the command, but also does not object to receiving it it seems.
 - Making it optional would require keeping track of this in the printer definitions somewhere (it seems printer-driver-ptouch does not do this, but just allows it everywhere, just only emits the command when explicitly set). As a first step here, I was thinking we could only emit the commend when `darkness_supported` is non-zero (and then later make that value conditional), but doing this from within `lprint_brother_rstartjob()` seemed a bit cumbersome, since the only (non-private) API I could find is `papplPrinterGetDriverData()`, which does a full memcpy of all driver data. So I left this for now.
