### PR TITLE
add dymo-400-twin-turbo definition

### DIFF
--- a/lprint-dymo.h
+++ b/lprint-dymo.h
@@ -35,6 +35,8 @@
   "MFG:DYMO;MDL:LabelWriter ;", NULL },
 { "dymo_lw-400-turbo",       "DYMO LabelWriter 400 Turbo",
   "MFG:DYMO;MDL:LabelWriter ;", NULL },
+{ "dymo_lw-400-twin-turbo",  "DYMO LabelWriter Twin Turbo",
+  "MFG:DYMO;MDL:LabelWriter ;", NULL },
 { "dymo_lw-450",             "DYMO LabelWriter 450",
   "MFG:DYMO;MDL:LabelWriter 450;", NULL },
 { "dymo_lw-450-duo-label",   "DYMO LabelWriter 450 DUO Label",


### PR DESCRIPTION
This adds the definition for the Dymo LabelWriter 400 Twin Turbo. The printer identifies itself simply as Dymo LabelWriter Twin Turbo. Related michaelrsweet/pappl#396