### PR TITLE
Fix media size truncation

### DIFF
--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -363,8 +363,8 @@ lprint_brother_rendpage(
   buffer[ 2] = 'z';
   buffer[ 3] = !strncmp(options->media.type, "continuous", 10) ? 0x04 : 0x0c;
   buffer[ 4] = 0;
-  buffer[ 5] = options->media.size_width / 100;
-  buffer[ 6] = options->media.size_length / 100;
+  buffer[ 5] = DIV_ROUND_CLOSEST(options->media.size_width, 100);
+  buffer[ 6] = DIV_ROUND_CLOSEST(options->media.size_length, 100);
 #if 1
   buffer[ 7] = options->header.cupsHeight & 255;
   buffer[ 8] = (options->header.cupsHeight >> 8) & 255;

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -363,8 +363,8 @@ lprint_brother_rendpage(
   buffer[ 2] = 'z';
   buffer[ 3] = !strncmp(options->media.type, "continuous", 10) ? 0x04 : 0x0c;
   buffer[ 4] = 0;
-  buffer[ 5] = DIV_ROUND_CLOSEST(options->media.size_width, 100);
-  buffer[ 6] = DIV_ROUND_CLOSEST(options->media.size_length, 100);
+  buffer[ 5] = LPRINT_PWG_TO_MM(options->media.size_width);
+  buffer[ 6] = LPRINT_PWG_TO_MM(options->media.size_length);
 #if 1
   buffer[ 7] = options->header.cupsHeight & 255;
   buffer[ 8] = (options->header.cupsHeight >> 8) & 255;

--- a/lprint-tspl.c
+++ b/lprint-tspl.c
@@ -322,8 +322,8 @@ lprint_tspl_rstartpage(
     darkness = 100;
 
   papplDevicePrintf(device, "SIZE %d mm,%d mm\n",
-      DIV_ROUND_CLOSEST(options->media.size_width, 100),
-      DIV_ROUND_CLOSEST(options->media.size_length, 100));
+      LPRINT_PWG_TO_MM(options->media.size_width),
+      LPRINT_PWG_TO_MM(options->media.size_length));
 
   switch (options->orientation_requested)
   {

--- a/lprint-tspl.c
+++ b/lprint-tspl.c
@@ -321,7 +321,9 @@ lprint_tspl_rstartpage(
   else if (darkness > 100)
     darkness = 100;
 
-  papplDevicePrintf(device, "SIZE %d mm,%d mm\n", options->media.size_width / 100, options->media.size_length / 100);
+  papplDevicePrintf(device, "SIZE %d mm,%d mm\n",
+      DIV_ROUND_CLOSEST(options->media.size_width, 100),
+      DIV_ROUND_CLOSEST(options->media.size_length, 100));
 
   switch (options->orientation_requested)
   {

--- a/lprint.h
+++ b/lprint.h
@@ -26,6 +26,13 @@
 
 
 //
+// Utility macros...
+//
+
+#  define DIV_ROUND_CLOSEST(n, d) ((n + d / 2) / d)
+
+
+//
 // Function annotations...
 //
 

--- a/lprint.h
+++ b/lprint.h
@@ -29,7 +29,7 @@
 // Utility macros...
 //
 
-#  define DIV_ROUND_CLOSEST(n, d) ((n + d / 2) / d)
+#  define LPRINT_PWG_TO_MM(n) ((n + 50) / 100)
 
 
 //


### PR DESCRIPTION
Some drivers truncate media dimensions when converting from hundredths of millimeters to millimeters, causing them to be sized 1mm too narrow.

For example, a 4×6" label is 10160 hundredths of mm wide. Integer division `10160 / 100 = 101`, but the correct rounded value is 102mm (101.6mm).

This patch adds a `DIV_ROUND_CLOSEST` macro (based on the Linux kernel macro of the same name) and uses it in the `SIZE` command to round to the nearest millimeter instead of truncating.