### PR TITLE
Add Marklife X4 to TSPL driver

### DIFF
--- a/lprint-tspl.h
+++ b/lprint-tspl.h
@@ -10,6 +10,8 @@
 { "tspl_203dpi",		"203dpi TSPL Label Printer", NULL, NULL },
 { "tspl_rollo-x1038_203dpi",	"Rollo X1038",
   "MFG:Printer;MDL:Thermal Printer;CMD:XPP,XL;", NULL },
+{ "tspl_marklife-x4_203dpi", "Marklife X4",
+   "MFG:Marklife ;MDL:X4;CMD:XPP,XL;", NULL },
 { "tspl_300dpi",		"300dpi TSPL Label Printer", NULL, NULL },
 { "tspl__vevor-y428bt_300dpi",	"Vevor Y428BT Label Printer",
    "MFG:VEVOR ;CMD: ;MODEL:Y428BT;DES:LabelPrinter;", NULL },


### PR DESCRIPTION
Adds the Marklife X4 4×6 thermal label printer to the TSPL device table for auto-detection.

The X4 is a USB thermal label printer that speaks TSPL2, confirmed by USB traffic capture against the Windows driver. It shares CMD:XPP,XL with the already-supported Rollo X1038.

```sh
$ ./lprint -o verbose devices
usb://MARKLIFE%20/X4?serial=0101
    MARKLIFE  X4 (USB)
    MFG:MARKLIFE ;CMD:XPP,XL;MDL:X4;CLS:PRINTER;DES:LABEL PRINTER;
```