### PR TITLE
Add udev rules for USB printer access on Linux

### DIFF
--- a/60-lprint.rules
+++ b/60-lprint.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{ID_USB_INTERFACES}=="*:0701*:", MODE="0664", GROUP="lp"

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -81,6 +81,14 @@ commands to install LPrint to "/usr/local/bin":
     make
     sudo make install
 
+On Linux, LPrint installs a udev rule that allows users in the "lp" group to
+access USB printers directly.  Make sure your user account is in the "lp" group
+before running LPrint:
+
+    sudo usermod -aG lp USERNAME
+
+You will need to log out and back in for the group change to take effect.
+
 The "configure" script supports the usual autoconf options - run:
 
     ./configure --help

--- a/Makefile.in
+++ b/Makefile.in
@@ -58,6 +58,7 @@ sharedstatedir	=	@sharedstatedir@
 srcdir		=	@srcdir@
 sysconfdir	=	@sysconfdir@
 top_srcdir	=	@top_srcdir@
+udevdir		=	@udevdir@
 unitdir		=	@unitdir@
 
 BUILDROOT	=	$(DSTROOT)$(RPM_BUILD_ROOT)$(DESTDIR)
@@ -102,6 +103,8 @@ OBJS		=	\
 			lprint-zpl.o
 TARGETS		=	\
 			lprint
+UDEVRULES	=	\
+			60-lprint.rules
 
 
 TESTOBJS	=	\
@@ -146,10 +149,17 @@ install:	all
 	    echo "Installing launchd service to $(BUILDROOT)/Library/LaunchDaemons..."; \
 	    $(INSTALL) -d -m 755 $(BUILDROOT)/Library/LaunchDaemons; \
 	    $(INSTALL) -c -m 644 org.msweet.lprint.plist $(BUILDROOT)/Library/LaunchDaemons; \
-	elif test "x$(unitdir)" != x; then \
-	    echo "Installing systemd service to $(BUILDROOT)$(unitdir)..."; \
-	    $(INSTALL) -d -m 755 $(BUILDROOT)$(unitdir); \
-	    $(INSTALL) -c -m 644 lprint.service $(BUILDROOT)$(unitdir); \
+	else \
+	    if test "x$(udevdir)" != x; then \
+	        echo "Installing udev rules to $(BUILDROOT)$(udevdir)..."; \
+	        $(INSTALL) -d -m 755 $(BUILDROOT)$(udevdir); \
+	        $(INSTALL) -c -m 644 60-lprint.rules $(BUILDROOT)$(udevdir); \
+	    fi; \
+	    if test "x$(unitdir)" != x; then \
+	        echo "Installing systemd service to $(BUILDROOT)$(unitdir)..."; \
+	        $(INSTALL) -d -m 755 $(BUILDROOT)$(unitdir); \
+	        $(INSTALL) -c -m 644 lprint.service $(BUILDROOT)$(unitdir); \
+	    fi \
 	fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,28 @@ AC_ARG_WITH([systemd], AS_HELP_STRING([--with-systemd[=PATH]], [install systemd 
 ])
 
 
+dnl udev support...
+udevdir=""
+AC_SUBST([udevdir])
+
+AC_ARG_WITH([udev], AS_HELP_STRING([--with-udev[=PATH]], [install udev rules, default=auto]), [
+    AS_CASE([$withval], [yes], [
+	with_udev=yes
+	udevdir="\$(prefix)/lib/udev/rules.d"
+    ], [no], [
+	with_udev=no
+    ], [
+	with_udev=yes
+	udevdir="$withval"
+    ])
+], [
+    AS_IF([test $host_os_name != darwin], [
+	with_udev=yes
+	udevdir="\$(prefix)/lib/udev/rules.d"
+    ])
+])
+
+
 dnl Support for experimental drivers...
 AC_ARG_ENABLE([experimental], AS_HELP_STRING([--enable-experimental], [turn on experimental drivers, default=no]))
 AS_IF([test x$enable_experimental = xyes], [


### PR DESCRIPTION
When installing LPrint from source on Linux, USB printers are not accessible to non-root users because LPrint uses libusb to access raw USB device nodes at `/dev/bus/usb/BUS/DEVICE`, which are not accessible without elevated privileges by default. This is unlike the CUPS approach which uses the `usblp` kernel module, whose devices are already covered by built-in kernel udev rules.

This PR adds a udev rule that grants members of the `lp` group read/write access to USB printer devices, matching them by USB interface class (`0701` — printer class, only valid subclass) rather than by VID/PID, so it works generically for any printer LPrint supports.

## Changes

- `60-lprint.rules`: new udev rule matching USB printer class devices and assigning them to the `lp` group with `MODE="0664"`
- `configure.ac`: adds `--with-udev[=PATH]` option for controlling installation of the rules file, defaulting to `$(prefix)/lib/udev/rules.d` on non-Darwin systems
- `Makefile.in`: installs the udev rules file on Linux, independently of the systemd service (so `--without-systemd` does not suppress udev rule installation)
- `DOCUMENTATION.md`: documents the `lp` group requirement for source installs

Note: snap users are unaffected — `snap connect lprint:raw-usb` already handles USB device access via snap confinement.