### PR TITLE
Add Phomemo PM-241-BT to the TSPL driver list

### DIFF
--- a/lprint-tspl.h
+++ b/lprint-tspl.h
@@ -12,6 +12,8 @@
   "MFG:Printer;MDL:Thermal Printer;CMD:XPP,XL;", NULL },
 { "tspl_marklife-x4_203dpi", "Marklife X4",
    "MFG:Marklife ;MDL:X4;CMD:XPP,XL;", NULL },
+{ "tspl_phomemo-pm-241-bt_203dpi", "Phomemo PM-241-BT",
+   "MFG:;MDL:PM-241-BT;CMD:XPP,XL;", NULL },
 { "tspl_300dpi",		"300dpi TSPL Label Printer", NULL, NULL },
 { "tspl__vevor-y428bt_300dpi",	"Vevor Y428BT Label Printer",
    "MFG:VEVOR ;CMD: ;MODEL:Y428BT;DES:LabelPrinter;", NULL },


### PR DESCRIPTION
This adds a driver list entry for the Phomemo PM-241-BT, a 4-inch
203dpi thermal label printer (USB ID 2e3c:5750) that speaks TSPL. The
existing TSPL driver code works with it unmodified.

The IEEE-1284 device ID reported by the printer is:

    MFG: ;CMD:XPP,XL;MDL:PM-241-BT;CLS:PRINTER;DES:PM-241-BT;

Note the blank MFG value, which is why the match string uses only MDL
and CMD.

Tested on the physical printer (Fedora 45, built from master with the
tspl changes cherry-picked onto v1.4.0 since CUPS 2.5 is not released
yet):

- lprint autoadd selects the new driver from the device ID
- printing PWG raster jobs through a CUPS "everywhere" queue
  (pdftopdf -> gstoraster -> IPP), including Japanese shipping labels
  with text, barcodes and QR codes
- raw TSPL jobs through the 9100 socket
- media sensing (GAP), density and feed behave correctly with the
  stock TSPL output

I own this printer and can test changes and help with any PM-241-BT
issues that get reported.

Assisted-by: Claude:claude-fable-5 [Claude Code]