### PR TITLE
Ptouch improvements

### DIFF
--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -173,9 +173,6 @@ lprintBrother(
     data->num_media = (int)(sizeof(lprint_brother_pt_media) / sizeof(lprint_brother_pt_media[0]));
     memcpy(data->media, lprint_brother_pt_media, sizeof(lprint_brother_pt_media));
 
-    data->num_source = 1;
-    data->source[0]  = "main-roll";
-
     cupsCopyString(data->media_ready[0].size_name, "oe_wide-2in-tape_1x2in", sizeof(data->media_ready[0].size_name));
     cupsCopyString(data->media_ready[0].type, "continuous", sizeof(data->media_ready[0].type));
 

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -205,38 +205,61 @@ lprint_brother_get_status(
   unsigned char		buffer[32];	// Status buffer
   pappl_preason_t	preasons;	// "printer-state-reasons" values
   const char		*media;		// "media-ready" value
+  ssize_t		rbytes;		// Bytes read in response
+  unsigned int		tries;		// Number of tries for reading response
 
 
   // Request status...
   if (!papplDevicePuts(device, "\033iS"))
+  {
+    papplLogPrinter(printer, PAPPL_LOGLEVEL_ERROR, "Failed to send status command.");
     return (false);
+  }
 
-  // Read status buffer...
-  if (papplDeviceRead(device, buffer, sizeof(buffer)) < (ssize_t)sizeof(buffer))
+  // Read status buffer...  Usually first few tries read empty
+  for (tries = 10; tries; tries --)
+  {
+    rbytes = papplDeviceRead(device, buffer, sizeof(buffer));
+    if (rbytes == (ssize_t)sizeof(buffer))
+    {
+      break;
+    }
+    else if (rbytes > 0)
+    {
+      // Never witnessed, but diagnose this just in case
+      papplLogPrinter(printer, PAPPL_LOGLEVEL_ERROR, "Receive partial status reply, read %li bytes.", rbytes);
+      return (false);
+    }
+  }
+  if (tries == 0)
+  {
+    papplLogPrinter(printer, PAPPL_LOGLEVEL_ERROR, "Status reply not received.");
     return (false);
+  }
 
   LPRINT_DEBUG("lprint_brother_get_status: Print Head Mark = %02x\n", buffer[0]);
   LPRINT_DEBUG("lprint_brother_get_status: Size = %02x\n", buffer[1]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[2]);
+  LPRINT_DEBUG("lprint_brother_get_status: Brother Code = %02x\n", buffer[2]);
   LPRINT_DEBUG("lprint_brother_get_status: Series Code = %02x\n", buffer[3]);
-  LPRINT_DEBUG("lprint_brother_get_status: Model Code = %02x %02x\n", buffer[4], buffer[5]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[6]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[7]);
+  LPRINT_DEBUG("lprint_brother_get_status: Model Code = %02x\n", buffer[4]);
+  LPRINT_DEBUG("lprint_brother_get_status: Country Code = %02x\n", buffer[5]);
+  LPRINT_DEBUG("lprint_brother_get_status: Battery Level = %02x\n", buffer[6]);
+  LPRINT_DEBUG("lprint_brother_get_status: Extended Error = %02x\n", buffer[7]);
   LPRINT_DEBUG("lprint_brother_get_status: Error Info 1 = %02x\n", buffer[8]);
   LPRINT_DEBUG("lprint_brother_get_status: Error Info 2 = %02x\n", buffer[9]);
   LPRINT_DEBUG("lprint_brother_get_status: Media Width = %02x\n", buffer[10]);
   LPRINT_DEBUG("lprint_brother_get_status: Media Type = %02x\n", buffer[11]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[12]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[13]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[14]);
+  LPRINT_DEBUG("lprint_brother_get_status: Number of Colors = %02x\n", buffer[12]);
+  LPRINT_DEBUG("lprint_brother_get_status: Fonts = %02x\n", buffer[13]);
+  LPRINT_DEBUG("lprint_brother_get_status: Japanese Fonts = %02x\n", buffer[14]);
   LPRINT_DEBUG("lprint_brother_get_status: Mode = %02x\n", buffer[15]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[16]);
+  LPRINT_DEBUG("lprint_brother_get_status: Density = %02x\n", buffer[16]);
   LPRINT_DEBUG("lprint_brother_get_status: Media Length = %02x\n", buffer[17]);
   LPRINT_DEBUG("lprint_brother_get_status: Status Type = %02x\n", buffer[18]);
   LPRINT_DEBUG("lprint_brother_get_status: Phase Type = %02x\n", buffer[19]);
   LPRINT_DEBUG("lprint_brother_get_status: Phase Number = %02x %02x\n", buffer[20], buffer[21]);
   LPRINT_DEBUG("lprint_brother_get_status: Notification # = %02x\n", buffer[22]);
-  LPRINT_DEBUG("lprint_brother_get_status: Reserved = %02x\n", buffer[23]);
+  LPRINT_DEBUG("lprint_brother_get_status: Expansion Area = %02x\n", buffer[23]);
   LPRINT_DEBUG("lprint_brother_get_status: Tape Color = %02x\n", buffer[24]);
   LPRINT_DEBUG("lprint_brother_get_status: Text Color = %02x\n", buffer[25]);
   LPRINT_DEBUG("lprint_brother_get_status: Hardware Info = %02x %02x %02x %02x\n", buffer[26], buffer[27], buffer[28], buffer[29]);
@@ -453,9 +476,8 @@ lprint_brother_rstartjob(
   }
 
   // Get status information...
+  // Ignore errors, since we are not using the result yet (lprint_brother_get_status will have logged an error)
   lprint_brother_get_status(papplJobGetPrinter(job), device);
-//  if (!lprint_brother_get_status(papplJobGetPrinter(job), device))
-//    return (false);
 
   // Reset and set raster mode...
   if (!papplDevicePuts(device, "\033@\033ia\001"))

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -396,6 +396,11 @@ lprint_brother_rendpage(
   if (!papplDeviceWrite(device, buffer, sizeof(buffer)))
     return (false);
 
+  // Set compression mode to uncompressed (default for some devices, but not
+  // all, so always set explicitly).
+  if (!papplDeviceWrite(device, (const unsigned char *)"M\0", 2))
+    return (false);
+
   // Send label data...
   if (brother->num_bytes > 0 && !papplDeviceWrite(device, brother->buffer, brother->num_bytes))
     return (false);

--- a/lprint-common.c
+++ b/lprint-common.c
@@ -815,7 +815,7 @@ lprintMediaUpdate(
 
   data->num_media = i;
 
-  LPRINT_DEBUG("lprintMediaUpdate: num_media=%d\n", data->num_media);
+  LPRINT_DEBUG("lprintMediaUpdate: num_media=%u\n", (unsigned)data->num_media);
   for (i = 0; i < data->num_media; i ++)
     LPRINT_DEBUG("lprintMediaUpdate: media[%d]='%s'\n", i, data->media[i]);
 }


### PR DESCRIPTION
A few small fixes to the brother driver. In particular it fixes the status read command, explicitly sets the compression mode (which is required on at least PT-E720BT according to #214) and some non-functional cleanups.