### PR TITLE
Ptouch WIP

### DIFF
--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -13,6 +13,13 @@
 // TODO: Make device-specific
 static unsigned int head_width = 128;
 
+// TODO: bottom_top should be device-dependent, columns also media-dependent (wider/narrower tape needs a bit more/less margin, 10 pixels is for 12mm).
+// bottom_top are specified in mm in docs (also in pixels, but then it becomes resolution dependent).
+// columns are specified in pixels in the docs, so keep that here (the horizontal resolution is also fixed).
+static unsigned min_bottom_top_margin = 200;
+static unsigned max_bottom_top_margin = 12700;
+static unsigned min_margin_columns = 10;
+
 //
 // Local types...
 //
@@ -163,13 +170,13 @@ lprintBrother(
     // PT-series...
 
     // Set resolution...
+    // TODO: Different models have different resolutions
     data->num_resolution  = 1;
     data->x_resolution[0] = data->y_resolution[0] = 180;
     data->x_default       = data->y_default = data->x_resolution[0];
 
-    // Basically borderless...
-    data->left_right = 1;
-    data->bottom_top = 1;
+    data->left_right = (min_margin_columns * 2540 + data->x_resolution[0] - 1) / data->x_resolution[0];
+    data->bottom_top = min_bottom_top_margin;
 
     // Supported media...
     data->num_media = (int)(sizeof(lprint_brother_pt_media) / sizeof(lprint_brother_pt_media[0]));
@@ -459,13 +466,59 @@ lprint_brother_rstartpage(
   lprint_brother_t *brother = (lprint_brother_t *)papplJobGetData(job);
 					// Brother driver data
   unsigned char	buffer[13];		// Print Information command buffer
+  unsigned bottom_top_margin, margin_rows;              // Vertical margin, in 1/100th mm and pixels
+  unsigned left_margin_columns, right_margin_columns;   // Horizontal margins in pixels
+  unsigned raster_rows;					// Number of rows of raster data that will be sent
 
 
   if (page > 0)
     papplDevicePuts(device, "\014");	// Eject the previous page
 
+  // Hardware has a single margin for top and bottom, so apply the smallest
+  // requested margin in hardware and reduce the other margin (this might cause
+  // supplied data inside the margin to be rendered when it maybe should not,
+  // but margins should be empty anyway...
+  if (options->media.top_margin < options->media.bottom_margin)
+    bottom_top_margin = options->media.top_margin;
+  else
+    bottom_top_margin = options->media.bottom_margin;
+
+  // Too small margins messes up output on some devices, so ensure the minimum is respected
+  if (bottom_top_margin < min_bottom_top_margin)
+    bottom_top_margin = min_bottom_top_margin;
+  // Untested what happens if you exceed the maximum amount, but enforce it anyway
+  if (bottom_top_margin > max_bottom_top_margin)
+    bottom_top_margin = max_bottom_top_margin;
+
+  margin_rows = options->header.HWResolution[0] * bottom_top_margin / 2540;
+
+  // This causes the hardware to add this margin before and after the label.
+  if (!papplDevicePrintf(device, "\033id%c%c", margin_rows & 0xff, margin_rows >> 8))
+    return (false);
+
+  left_margin_columns = options->header.HWResolution[0] * (unsigned)options->media.left_margin / 2540;
+  right_margin_columns = options->header.HWResolution[0] * (unsigned)options->media.right_margin / 2540;
+  if (left_margin_columns < min_margin_columns)
+    left_margin_columns = min_margin_columns;
+  if (right_margin_columns < min_margin_columns)
+    right_margin_columns = min_margin_columns;
+
+  // Then instruct the dither code to respect the margins. For the rows, the
+  // margin is omitted for the raster data and filled in by the hardware. For
+  // the columns, this causes the margins to become white in the raster data.
+  options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxLeft]   = left_margin_columns;
+  options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxTop]    = margin_rows;
+  options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxRight]  = options->header.cupsWidth - right_margin_columns - 1;
+  options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxBottom] = options->header.cupsHeight - margin_rows - 1;
+
+  papplLogJob(job, PAPPL_LOGLEVEL_DEBUG, "Starting new page, margins: bottom_top_margin=%u, margin_rows=%u, left_margin_colums=%u, right_margin_colums=%u", bottom_top_margin, margin_rows, left_margin_columns, right_margin_columns);
+  papplLogJob(job, PAPPL_LOGLEVEL_DEBUG, "Imagebox: left=%u, right=%u, top=%u, bottom=%u", options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxLeft], options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxRight], options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxTop], options->header.cupsInteger[CUPS_RASTER_PWG_ImageBoxBottom]);
+  // TODO: When not doing precut, the margin also becomes (effectively) bigger. Should we handle this somehow?
+
   if (!lprintDitherAlloc(&brother->dither, job, options, /*head_width*/head_width, CUPS_CSPACE_K, options->header.HWResolution[0] == 300 ? 1.2 : 1.0, /*out_mirror*/true))
     return (false);
+
+  raster_rows = options->header.cupsHeight - 2 * margin_rows;
 
   // Send print information...
   buffer[ 0] = 0x1b;
@@ -475,10 +528,10 @@ lprint_brother_rstartpage(
   buffer[ 4] = 0;
   buffer[ 5] = LPRINT_PWG_TO_MM(options->media.size_width);
   buffer[ 6] = LPRINT_PWG_TO_MM(options->media.size_length);
-  buffer[ 7] = options->header.cupsHeight & 255;
-  buffer[ 8] = (options->header.cupsHeight >> 8) & 255;
-  buffer[ 9] = (options->header.cupsHeight >> 16) & 255;
-  buffer[10] = (options->header.cupsHeight >> 24) & 255;
+  buffer[ 7] = raster_rows & 255;
+  buffer[ 8] = (raster_rows >> 8) & 255;
+  buffer[ 9] = (raster_rows >> 16) & 255;
+  buffer[10] = (raster_rows >> 24) & 255;
   buffer[11] = page == 0 ? 0 : 1;
   buffer[12] = 0;
 

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -367,36 +367,10 @@ lprint_brother_rendpage(
 {
   lprint_brother_t	*brother = (lprint_brother_t *)papplJobGetData(job);
 					// Brother driver data
-  unsigned char	buffer[13];		// Print Information command buffer
 
 
   // Write last line
   lprint_brother_rwriteline(job, options, device, options->header.cupsHeight, NULL);
-
-  // Send print information...
-  buffer[ 0] = 0x1b;
-  buffer[ 1] = 'i';
-  buffer[ 2] = 'z';
-  buffer[ 3] = !strncmp(options->media.type, "continuous", 10) ? 0x04 : 0x0c;
-  buffer[ 4] = 0;
-  buffer[ 5] = LPRINT_PWG_TO_MM(options->media.size_width);
-  buffer[ 6] = LPRINT_PWG_TO_MM(options->media.size_length);
-#if 1
-  buffer[ 7] = options->header.cupsHeight & 255;
-  buffer[ 8] = (options->header.cupsHeight >> 8) & 255;
-  buffer[ 9] = (options->header.cupsHeight >> 16) & 255;
-  buffer[10] = (options->header.cupsHeight >> 24) & 255;
-#else
-  buffer[ 7] = brother->count & 255;
-  buffer[ 8] = (brother->count >> 8) & 255;
-  buffer[ 9] = (brother->count >> 16) & 255;
-  buffer[10] = (brother->count >> 24) & 255;
-#endif // 1
-  buffer[11] = page == 0 ? 0 : 1;
-  buffer[12] = 0;
-
-  if (!papplDeviceWrite(device, buffer, sizeof(buffer)))
-    return (false);
 
   // Send label data...
   if (brother->num_bytes > 0 && !papplDeviceWrite(device, brother->buffer, brother->num_bytes))
@@ -484,12 +458,31 @@ lprint_brother_rstartpage(
 {
   lprint_brother_t *brother = (lprint_brother_t *)papplJobGetData(job);
 					// Brother driver data
+  unsigned char	buffer[13];		// Print Information command buffer
 
 
   if (page > 0)
     papplDevicePuts(device, "\014");	// Eject the previous page
 
   if (!lprintDitherAlloc(&brother->dither, job, options, /*head_width*/head_width, CUPS_CSPACE_K, options->header.HWResolution[0] == 300 ? 1.2 : 1.0, /*out_mirror*/true))
+    return (false);
+
+  // Send print information...
+  buffer[ 0] = 0x1b;
+  buffer[ 1] = 'i';
+  buffer[ 2] = 'z';
+  buffer[ 3] = !strncmp(options->media.type, "continuous", 10) ? 0x04 : 0x0c;
+  buffer[ 4] = 0;
+  buffer[ 5] = LPRINT_PWG_TO_MM(options->media.size_width);
+  buffer[ 6] = LPRINT_PWG_TO_MM(options->media.size_length);
+  buffer[ 7] = options->header.cupsHeight & 255;
+  buffer[ 8] = (options->header.cupsHeight >> 8) & 255;
+  buffer[ 9] = (options->header.cupsHeight >> 16) & 255;
+  buffer[10] = (options->header.cupsHeight >> 24) & 255;
+  buffer[11] = page == 0 ? 0 : 1;
+  buffer[12] = 0;
+
+  if (!papplDeviceWrite(device, buffer, sizeof(buffer)))
     return (false);
 
   brother->count     = 0;

--- a/lprint-brother.c
+++ b/lprint-brother.c
@@ -10,6 +10,8 @@
 #include "lprint.h"
 #ifdef LPRINT_EXPERIMENTAL
 
+// TODO: Make device-specific
+static unsigned int head_width = 128;
 
 //
 // Local types...
@@ -487,7 +489,7 @@ lprint_brother_rstartpage(
   if (page > 0)
     papplDevicePuts(device, "\014");	// Eject the previous page
 
-  if (!lprintDitherAlloc(&brother->dither, job, options, /*head_width*/0, CUPS_CSPACE_K, options->header.HWResolution[0] == 300 ? 1.2 : 1.0, /*out_mirror*/false))
+  if (!lprintDitherAlloc(&brother->dither, job, options, /*head_width*/head_width, CUPS_CSPACE_K, options->header.HWResolution[0] == 300 ? 1.2 : 1.0, /*out_mirror*/true))
     return (false);
 
   brother->count     = 0;


### PR DESCRIPTION
These are some WIP commits for Ptouch that I would like to share and discuss.

They are nowwhere near ready for merging, but having a bit of code to look at might make it easier to talk about this.

### Output head size & mirroring
Following the discussion in https://github.com/michaelrsweet/lprint/issues/15#issuecomment-4974775002, this uses the new dithering code to set the output head size and enable mirroring, so the output will be properly positioned on the tape.

The basic idea is simple, but I've hardcoded the 128-pixel-wide head size of my E550W.

I guess we should add a struct with some hardware parameters, that is then put into `pappl_pr_driver_t::extension`? With the current structure this seems tricky. Since `extension` is a pointer, I think you need to declare a global (static) instance of that struct for each driver and then reference that with `&foo`? But since the driver list in `lprint-brother.h` is now included inside an array definition in `lprint.c`, there is no way to add static global vars to `lprint-brother.h`, and putting them in a separate is probably not ideal?

Would it make sense to have a separate driver array for each type of printer and define that in the corresponding .c file, and then have one array that references each of those (or copy them into a single array on startup maybe)? Then it is easier to define these objects together with their drivers (OTOH you would still separate the list of objects from the list of drivers, which is not supernice..).

If you have suggestions on how to approach this, I'm happy to implement it and/or figure out the settings to be used for each of the currently supported devices.

### Margin handling

I have found that at least some hardware (my E550W) wants an explicit set margin command to work. This margin adds a bit of feed before the printable content starts. There are two main caveats:
 1. I believe this margin is device-dependent (though the P900 and E550 manuals I looked at both have 2mm margin). These values could be added to the driver-info struct discussed above.
 2. Just sending the command would be enough to make printing work, but then the label size will not have the right size.

About the second item, the margin sent to the hardware will be *added* to the print area. So if the print area matches the label lenght exactly, the label will be too long, so this should be subtracted from the label area. However, the dithering code currently already skips the top and bottom margins specified in the selected media, so if these margins could be made to match, everything should be ok.

It is not entirely clear to me how the media margins are handled, I think that when a PWG media name is used, pappl will use the default media with the size updated to the size specified in the name  (so keeping the default margins), but a client can also specify a `media-col` and the margins can be whatever. At first glance pappl does not seem to validate the margins against the `margin-xxx-supported` properties or the `data->botom_top` variables, I think? I also am not entirely sure what the margins specified by a client are supposed to mean - I think they select between multiple operation modes with different margins, so they should not specify arbitrary margins? And is a client allowed to put content in the margin? If they do, is the printer expected to not print the content in that margin?

Just setting `botttom_top` did not seem to apply the new margins. Later I accidentally discovered that re-creating the printer would put the `bottom_top` value in the media-default, meaning it would be applied to print jobs by default, but I think it could still be overridden by a client (though I have not tried to figure out how to do that with the `lprint` commandline yet).

So my idea was to store the minimum required margins in `data->bottom_top` and then do some enforcing in lprint to:
 1. Ensure the top and bottom margins are at least as big as the minimum (if the client submitted smaller margins and put content in the real margin area, this would cut off content - the alternative could be to make the label longer).
 2. Ensure that the top and bottom margins are the same - the hardware only has a single setting for top and bottom margins. If they differ, make the bigger margin smaller (better to print some content that is in the margin, than to cut off content that was outside of the specified margins).
 
 I implemented this in the start job callback, but then found it did not actually work: it seems there are separate options for the job and each printed document, so start job cannot modify the margins used by the papple (e.g.) PNG print filter. I left the code in to illustrate the idea, but it does not work.


For the horizontal margins, a similar issues exists, where the minimum margin should be enforced so the dithering code will leave enough empty room at the sides. This could be solved when calling the dithering by setting the imagebox explicitly, without actually needing to change the margins (coming to think of it, I guess this can actually also be done for the vertical margins, so maybe this is a solution)?

One extra challenge is that the horizontal margin is media-dependent (and probably also device-dependent, but that is a bit tricky since the margins are specified in pixels, not mm and relative to the print head and not the label width). I can further investigate to see how much difference there is between devices here.


One additional thing I notice, is a discrepancy in how the imagebox is defined, Lprint dithering does:

https://github.com/michaelrsweet/lprint/blob/b55366f153b35488fd8779784fdc0b844ef685ac/lprint-common.c#L62

whlie libcups does:

https://github.com/OpenPrinting/libcups/blob/d75c06104325095af9439449de558082b3f9fced/cups/raster-stream.c#L368

Haven't checked what cups 2.5 does. Not sure what is correct, but it seems that the current dithering code, combined with the libcups imagebox produces output that is one line too long (the top margin is 13px when it should be 14, bottom margin is ok).

Might be sidestepped completely by setting the imagebox explicitly, but it suggests an off-by-one error in either of these.


So in conclusion, I think it would make sense to redo the code I have in the startpage callback: have it convert the margins to pixels first, then apply the same logic to the pixel margins and put the result into the imagebox before allocing the dither? Then the user-supplied margins are respected (using hardware margins as much as possible, saving raster data), except when they are too small, then the minimum margins are used instead.

I would have investigated a bit more, but out of time for today, so wanted to share my thoughts as-is already.